### PR TITLE
fix: security hardening & bug fixes (SQL injection, XSS, UB, crash)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,280 @@
+# Changelog
+
+## [Unreleased]
+
+## [Session 1] — 2026-03-09
+
+### Fixed
+
+---
+
+#### BUG-01 — SQL-Injection in `status.php` (Schwere: **KRITISCH**)
+
+**Was war das Problem?**  
+Der ESP32 ruft `status.php` mit GET-Parametern auf, um Feuchtewerte in die Datenbank
+zu schreiben (`oah`) und die Schwellwerte zu aktualisieren (`t1`, `t2`).  
+Der ursprüngliche Code baute die SQL-Queries per String-Konkatenation zusammen:
+
+```php
+db_query("INSERT INTO Humidity (Average) VALUES ('".$_REQUEST['oah']."')");
+db_query("UPDATE Config SET Value='".$_REQUEST['t1']."' WHERE Id='Threshold1'");
+```
+
+Ein Angreifer, der die IP des ESP32 im Netzwerk kennt, hätte über einen manipulierten
+URL-Aufruf beliebige SQL-Befehle einschleusen können — z. B. alle Tabellen löschen
+(`'; DROP TABLE Humidity; --`) oder Zugangsdaten auslesen.
+
+**Wie wurde es behoben?**  
+Alle drei Queries nutzen jetzt MySQLi Prepared Statements.  Der Nutzerwert wird als
+typisierter Parameter gebunden und niemals in den SQL-String eingefügt:
+
+```php
+$oah = (float)($_REQUEST['oah'] ?? 0);
+$stmt = $dbcon->prepare("INSERT INTO Humidity (Average) VALUES (?)");
+$stmt->bind_param("d", $oah);
+$stmt->execute();
+```
+
+Der Typ-Cast auf `(float)` bzw. `(int)` vor dem Binding ist eine zusätzliche
+Absicherung, die sicherstellt, dass nur numerische Werte die Datenbank erreichen.
+
+---
+
+#### BUG-02 — Stored XSS in `index.php` (Schwere: **HOCH**)
+
+**Was war das Problem?**  
+`index.php` liest Feuchte- und Schwellwert-Einträge aus der Datenbank und gibt sie
+direkt als JavaScript-Literale aus:
+
+```php
+{t:'<?=$row2['Start']?>', y:<?=$row['Upper']?>},
+{t:'<?=$x[0]?>', y:<?=$x[1]?>},
+```
+
+Wenn ein Angreifer es schafft, einen manipulierten Datums- oder Textwert in die
+Datenbank einzuschleusen (z. B. über BUG-01, bevor dieser behoben war), würde
+dieser Wert ungefiltert in die HTML-Seite eingebettet.  Ein Datum wie
+`2026-03-09</script><script>alert(1)` würde als JavaScript ausgeführt werden — ein
+klassischer Stored-XSS-Angriff, mit dem Cookies gestohlen oder weitere Skripte
+nachgeladen werden können.
+
+**Wie wurde es behoben?**  
+- Numerische Datenbankwerte (`Upper`, `Lower`, `Average`) werden mit `(float)` gecastet.
+  En Zahlen-Cast kann keine HTML-/JS-Sonderzeichen enthalten.
+- Datums-Strings werden mit `htmlspecialchars(..., ENT_QUOTES, 'UTF-8')` escapiert,
+  bevor sie in den JavaScript-String-Kontext eingebettet werden.  Sonderzeichen wie
+  `<`, `>`, `"`, `'` werden so in harmlose HTML-Entities umgewandelt:
+
+```php
+{t:'<?=htmlspecialchars((string)$row2['Start'], ENT_QUOTES, 'UTF-8')?>', y:<?=(float)$row['Upper']?>},
+```
+
+---
+
+#### BUG-03 — Undefiniertes Verhalten: `String == NULL` in `Plantcare.ino` (Schwere: **MITTEL**)
+
+**Was war das Problem?**  
+An vier Stellen wurden Arduino-`String`-Objekte mit `NULL` verglichen:
+
+```cpp
+if (ssid != NULL && pwd != NULL) { ... }
+if (emptyWaterURL == NULL) { ... }
+if (reportURL == NULL)     { ... }
+if (stylesheet == NULL)    { ... }
+```
+
+`String` ist eine C++-Klasse.  Der `==`-Operator ruft intern `compareTo()` auf, was
+wiederum `strcmp()` auf dem internen C-String-Zeiger ausführt.  Wird dabei `NULL`
+übergeben, ist das Verhalten laut C++-Standard undefiniert (Null-Pointer-Dereferenz
+in `strcmp`) — auf dem ESP32 kann das zu einem CPU-Exception-Absturz führen.
+Erschwerend greift `prefs.getString()` sowieso niemals `NULL` zurück, sondern `""`
+wenn der NVS-Key nicht existiert — der Vergleich war daher auch semantisch falsch.
+
+**Wie wurde es behoben?**  
+Alle vier Vergleiche wurden durch die typsichere Arduino-API `.isEmpty()` ersetzt,
+die korrekt prüft ob der String leer ist:
+
+```cpp
+if (!ssid.isEmpty() && !pwd.isEmpty()) { ... }
+if (emptyWaterURL.isEmpty()) { ... }
+```
+
+---
+
+#### BUG-04 — Pointer-Arithmetik statt String-Konkatenation in `Plantcare.ino` (Schwere: **MITTEL**)
+
+**Was war das Problem?**  
+In `doEmptyWaterWarning()` und `doStatusReporting()` wurde der HTTP-Statuscode
+mit einem String-Literal addiert:
+
+```cpp
+debugln(DEBUG_VERBOSE, "Response: " + httpResponseCode);
+```
+
+In C++ ist `"Response: "` ein `const char*`-Zeiger (kein `String`-Objekt).
+Das `+`-Zeichen führt hier **Zeiger-Arithmetik** aus: es verschiebt den Zeiger
+um `httpResponseCode` Bytes weiter in den Speicher.  Bei einem Rückgabecode von
+z. B. `200` zeigt der Zeiger damit 200 Zeichen hinter dem Anfang des String-Literals
+— also in beliebigen Speicher.  Das Ergebnis ist undefiniertes Verhalten: je nach
+Laufzeit wurde Speichermüll ausgegeben, das Programm abgestürzt oder (im Worst Case)
+ein Sicherheitsproblem durch das Auslesen fremder Speicherbereiche erzeugt.
+
+**Wie wurde es behoben?**  
+Durch explizites Erzeugen eines Arduino-`String`-Objekts aus dem Literal wird der
+`+`-Operator korrekt als String-Konkatenation aufgelöst:
+
+```cpp
+debugln(DEBUG_VERBOSE, String("Response: ") + httpResponseCode);
+```
+
+---
+
+#### BUG-05 — Division durch Null bei Erststart ohne konfigurierten Sensor (Schwere: **MITTEL**)
+
+**Was war das Problem?**  
+Beim allerersten Einschalten (leere NVS, noch kein Sensor aktiviert) war
+`numberOfActiveSensors == 0`.  Kurz danach wurde trotzdem dividiert:
+
+```cpp
+overallAverageHumidity /= numberOfActiveSensors;  // Division durch 0!
+```
+
+Dasselbe tritt in `loop()` auf wenn `sensorcount == 0`.  Ganzzahl-Division durch 0
+ist auf dem ESP32 eine CPU-Exception (Illegal Instruction), die den Watchdog-Reset
+auslöst und den Controller in einer Boot-Schleife gefangen hält.
+Das war tatsächlich der Grund, warum der Code bereits danach einen Fallback hat,
+der beim Erststart mindestens einen Sensor aktiviert — aber der Fallback kommt
+erst *nach* der Division.
+
+**Wie wurde es behoben?**  
+Schutzabfragen vor beiden Divisionen; der `overallAverageHumidity`-Wert bleibt
+bei `0.0` wenn kein Sensor aktiv ist (was den Pump-Trigger korrekt verhindert):
+
+```cpp
+if (numberOfActiveSensors > 0)
+    overallAverageHumidity /= numberOfActiveSensors;
+```
+
+---
+
+#### BUG-06 — Data Race auf globalen Variablen durch WiFiEvent-FreeRTOS-Task (Schwere: **MITTEL**, teilweise behoben)
+
+**Was war das Problem?**  
+`WiFiEvent()` wird vom ESP32-WiFi-Stack in einem eigenen FreeRTOS-Task aufgerufen —
+also in einem echten Parallelthread.  Dieser Task schreibt ohne jede Synchronisierung
+auf Variablen, die auch der Haupt-Loop liest und schreibt:
+
+- `ssid`, `pwd` (Arduino `String`-Objekte — deren internes Heap-Management ist nicht
+  thread-safe)
+- `checkWifiConnectionFlag` (`bool`)
+- `debugBufferArray`, `debugBufferIndexNextEmpty`, `debugBufferIndexLastShown`
+
+Ein gleichzeitiger schreibender und lesender Zugriff auf dieselbe Variable aus zwei
+Threads ohne Memory Barrier ist laut C++-Standard ein **Data Race** und damit
+undefiniertes Verhalten.  In der Praxis kann es zu korrupten String-Inhalten,
+falschem Reconnect-Verhalten oder einem korrupten Debug-Ringpuffer führen.
+
+**Was wurde getan?**  
+`checkWifiConnectionFlag` wurde als `volatile bool` deklariert.  Das verhindert,
+dass der Compiler den Wert in einem CPU-Register cached und ihn damit gegenüber
+dem anderen Thread unsichtbar macht.  Das ist eine minimale, aber nicht vollständige
+Lösung: `volatile` garantiert keine atomare Lese-Schreib-Reihenfolge und schützt
+nicht die `String`-Objekte.
+
+**Warum nicht vollständig behoben?**  
+Eine vollständige Lösung erfordert FreeRTOS-Semaphoren (`xSemaphoreCreateMutex()`)
+oder das Ersetzen von `WiFiEvent` durch eine Queue-basierte Kommunikation.
+Beides würde die Firmware-Architektur erheblich verändern und liegt außerhalb des
+Scope eines Hardening-Passes ohne Verhaltensänderung.  Der Bug ist in den
+Known Limitations dokumentiert.
+
+---
+
+#### BUG-07 — WiFi-Passwort im HTTP-abrufbaren Debug-Puffer (Schwere: **MITTEL**)
+
+**Was war das Problem?**  
+Im `ARDUINO_EVENT_WIFI_STA_GOT_IP`-Handler wurde das WiFi-Passwort in den
+Debug-Ringpuffer geschrieben:
+
+```cpp
+debugln(DEBUG_TRACE, "Password: " + WiFi.psk());
+```
+
+Der Debug-Ringpuffer ist über die HTTP-Endpunkte `/Da`, `/Db`, `/Dc` des eingebauten
+Webservers für jeden im selben Netzwerk ohne Authentifizierung abrufbar.
+Jeder, der die IP des ESP32 kennt, konnte damit das WLAN-Passwort im Klartext
+abfragen — besonders kritisch, da es sich um das Heimnetzwerk-Passwort handelt.
+
+**Wie wurde es behoben?**  
+Die betreffende Zeile wurde ersatzlos entfernt.  Das Passwort wird an keiner Stelle
+mehr geloggt.  Der SSID-Name (nicht sicherheitskritisch) wird weiterhin geloggt.
+
+---
+
+#### BUG-08 — Toter Code: doppelter `GET /M`-Handler in `webServerReaction()` (Schwere: **NIEDRIG**)
+
+**Was war das Problem?**  
+In der `else if`-Kette des HTTP-Request-Parsers gab es zwei identische Zweige für
+`GET /M`:
+
+```cpp
+} else if (currentLine.startsWith("GET /M")) {
+    page = PAGE_MODE;          // ← dieser wird immer getroffen
+} else if (currentLine.startsWith("GET /O")) {
+    page = PAGE_HUMIDITY;
+} else if (currentLine.startsWith("GET /M")) {  // ← dieser ist dead code!
+    page = PAGE_MODE;
+}
+```
+
+Da die erste `GET /M`-Prüfung alle passenden Requests abfängt, wird die zweite
+niemals ausgeführt.  Toter Code ist zwar kein direktes Sicherheits- oder
+Stabilitätsproblem, erhöht aber die Wartungslast und kann bei zukünftigen
+Änderungen zu Verwirrung führen (z. B. wenn jemand den ersten Block ändert,
+ohne zu wissen, dass noch ein zweiter existiert).
+
+**Wie wurde es behoben?**  
+Der zweite, unerreichbare `GET /M`-Block wurde entfernt.
+
+---
+
+### Added
+
+- **IMP-01** — Fehlender HTTP-Timeout in `doEmptyWaterWarning()` und `doStatusReporting()`
+
+  Beide Funktionen führen einen HTTP GET-Request durch, ohne einen Timeout zu setzen.
+  Wenn der Ziel-Server nicht antwortet, blockiert `http.GET()` (je nach HTTP-Client-
+  Implementierung) theoretisch unbegrenzt lang im Haupt-Loop — genau während der
+  Pump-Abschaltelogik läuft.  Das kann dazu führen, dass die Pumpe länger als
+  konfiguriert läuft und im schlimmsten Fall den Wassertank leerpumpt.
+  `http.setTimeout(5000)` setzt ein explizites 5-Sekunden-Limit für den
+  Verbindungsaufbau.
+
+- **IMP-02** — Rückgabewert von `prefs.begin()` nicht geprüft
+
+  `prefs.begin("p")` initialisiert das NVS-Subsystem (Non-Volatile Storage).  Schlägt
+  dies fehl (z. B. Flash-Fehler, korrupte Partition), gibt die Funktion `false` zurück.
+  Im Originalcode wurde der Rückgabewert ignoriert; alle nachfolgenden `prefs.getInt()`-
+  Aufrufe liefern dann `0` zurück, was zu unerwarteten Default-Werten führt.
+  Jetzt wird der Fehler erkannt und im Debug-Log gemeldet, damit der Anwender weiß,
+  dass er mit Default-Werten arbeitet.
+
+- Doxygen-kompatibler Datei-Header in `Plantcare.ino` (Zweck, Concurrency, Build,
+  Ownership).
+
+- Doxygen-Kommentare für alle public Functions: `mapf`, `doEmptyWaterWarning`,
+  `doStatusReporting`, `getAvgValues`, `startPump`, `stopPump`, `connectToWiFi`,
+  `doCheckWiFiConnection`, `WiFiEvent`, `webServerReaction`, `wpsSetup`.
+
+### Changed
+
+- `checkWifiConnectionFlag` als `volatile bool` deklariert (minimale Absicherung
+  gegen Compiler-Optimierung bei FreeRTOS-Task-Zugriff, BUG-06 partial mitigation).
+
+### Known Limitations
+
+- **BUG-06** (dokumentiert, nicht vollständig behoben): `WiFiEvent` läuft in einem
+  separaten FreeRTOS-Task und schreibt ohne Mutex auf `ssid`, `pwd`,
+  `debugBufferArray` u. a.  Eine vollständige Lösung erfordert FreeRTOS-Semaphoren
+  oder ein dediziertes Message-Queue-Pattern und würde die Architektur wesentlich
+  verändern.  Für einen Hobbyisten-Betrieb akzeptiert; Vollfix als Future Work.

--- a/Plantcare.ino
+++ b/Plantcare.ino
@@ -1,16 +1,30 @@
-/* ---------------------------------------------------------------------------
- * Needs Boards
- *	"esp32" by Espressif Systems ( https://github.com/espressif/arduino-esp32 )
- * Needs Libraries
- *	"URLCode" by XieXuan ( https://github.com/MR-XieXuan/URLCode_for_Arduino )
- *	"incbin" by Dale Weiler ( https://github.com/AlexIII/incbin-arduino )
- * Tested on
- *	"WEMOS D1 MINI ESP32"
- * Fritzing parts
- *	ESP32 https://forum.fritzing.org/t/doit-esp32-devkit-v1-30-pin/8443/3
- *	Sensor https://github.com/OgreTransporter/fritzing-parts-extra/
- *	Relais https://forum.fritzing.org/t/kf-301-relay-request/7992/10
- * ------------------------------------------------------------------------ */
+/**
+ * @file Plantcare.ino
+ * @brief Automatic plant watering system for ESP32 (WEMOS D1 MINI ESP32).
+ *
+ * Reads up to three capacitive soil-moisture sensors, controls a relay-driven pump
+ * via a two-threshold hysteresis loop, and reports telemetry to optional HTTP endpoints.
+ * A built-in WiFi web server provides configuration and debug pages.
+ *
+ * @section concurrency Concurrency
+ * WiFiEvent() is called from a separate FreeRTOS task.  Access to shared globals
+ * (ssid, pwd, checkWifiConnectionFlag, debugBuffer*) from that context is not
+ * mutex-protected — see BUG-06.  checkWifiConnectionFlag is declared volatile as a
+ * minimal guard; full correctness would require a FreeRTOS mutex.
+ *
+ * @section build Build
+ * Arduino IDE with Espressif ESP32 board package.
+ * Required libraries: URLCode (XieXuan), incbin (AlexIII).
+ * Tested on WEMOS D1 MINI ESP32.
+ *
+ * @section ownership Ownership
+ * All global state is owned by the main loop task, except where noted.
+ *
+ * Fritzing parts:
+ *   ESP32   https://forum.fritzing.org/t/doit-esp32-devkit-v1-30-pin/8443/3
+ *   Sensor  https://github.com/OgreTransporter/fritzing-parts-extra/
+ *   Relais  https://forum.fritzing.org/t/kf-301-relay-request/7992/10
+ */
 #include <Arduino.h>
 #include <esp_wps.h>
 #include <HTTPClient.h>
@@ -90,7 +104,10 @@ double overallAverageHumidity, lastOverallAverageHumidity;
 WiFiServer server(80);
 unsigned long startOfMainLoopMillis, lastMillis60s, startPumpMillis, lastPumpStartMillis, refreshPagesMillis;
 int page, subpage;
-bool checkWifiConnectionFlag = true, humidityThresholdHysteresisFalling, serialDebug, serialDebugActive;
+// checkWifiConnectionFlag is written from the WiFiEvent FreeRTOS task; volatile prevents
+// the compiler from caching the value in a register (BUG-06 partial mitigation).
+volatile bool checkWifiConnectionFlag = true;
+bool humidityThresholdHysteresisFalling, serialDebug, serialDebugActive;
 String ssid, pwd, emptyWaterURL, reportURL, stylesheet;
 int humidityThresholdUpper, humidityThresholdLower, pumpDelay1InMinutes, pumpDelayNInMinutes, dryWetPumpBorderValue;
 double pumpRuntime1InSeconds, pumpRuntimeNInSeconds;
@@ -151,6 +168,16 @@ template<typename... Args> void debugln(const int level, Args... args) {
   }
 }
 
+/**
+ * @brief Linear interpolation for floating-point values.
+ *
+ * @param x      Input value.
+ * @param in_min Lower bound of input range.
+ * @param in_max Upper bound of input range.
+ * @param out_min Lower bound of output range.
+ * @param out_max Upper bound of output range.
+ * @return Mapped value.  Not clamped — callers must validate ranges.
+ */
 double mapf(const double x, const double in_min, const double in_max, const double out_min, const double out_max) {
   return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;
 }
@@ -166,7 +193,10 @@ void setup() {
   pinMode(PUMP_ACTIVE_GPIO_NUMBER, OUTPUT);
   digitalWrite(PUMP_ACTIVE_GPIO_NUMBER, HIGH);  // The used relais is LOW active!
 
-  prefs.begin("p");
+  // IMP-02: check NVS initialisation; log on failure and continue with defaults.
+  if (!prefs.begin("p")) {
+    debugln(DEBUG_ERROR, "NVS init failed, all settings will use defaults");
+  }
 
   int numberOfActiveSensors = 0;
   overallAverageHumidity = 0;
@@ -195,7 +225,9 @@ void setup() {
       overallAverageHumidity += mapf(averageHumidity[v], sensorDryHumidity[v], sensorWetHumidity[v], 0, 100);
     }
   }
-  overallAverageHumidity /= numberOfActiveSensors;
+  // BUG-05 fix: guard against division by zero on first boot before any sensor is configured.
+  if (numberOfActiveSensors > 0)
+    overallAverageHumidity /= numberOfActiveSensors;
 
   ssid = prefs.getString("ssid");
   pwd = prefs.getString("password");
@@ -245,11 +277,11 @@ void setup() {
     dryWetPumpBorderValue = 250;  // Dry: ~130 mA, Submerged: ~430 Ah // TODO
     prefs.putInt("drypump", dryWetPumpBorderValue);
   }
-  if (emptyWaterURL == NULL) {
+  if (emptyWaterURL.isEmpty()) {  // BUG-03 fix: .isEmpty() instead of == NULL
     emptyWaterURL = DEFAULT_URL_EMPTY;
     prefs.putString("emptyUrl", emptyWaterURL);
   }
-  if (reportURL == NULL) {
+  if (reportURL.isEmpty()) {  // BUG-03 fix: .isEmpty() instead of == NULL
     reportURL = DEFAULT_URL_STATUS;
     prefs.putString("reportURL", reportURL);
   }
@@ -257,7 +289,7 @@ void setup() {
     debugLevel = DEBUG_INFO;
     prefs.putInt("debugLevel", debugLevel);
   }
-  if (stylesheet == NULL) {
+  if (stylesheet.isEmpty()) {  // BUG-03 fix: .isEmpty() instead of == NULL
     stylesheet = DEFAULT_STYLESHEET;
     prefs.putString("stylesheet", stylesheet);
   }
@@ -295,7 +327,9 @@ void loop() {
       sensorcount++;
     }
   }
-  overallAverageHumidity /= sensorcount;
+  // BUG-05 fix: guard against division by zero if all sensors are somehow inactive.
+  if (sensorcount > 0)
+    overallAverageHumidity /= sensorcount;
 
   debugln(DEBUG_TRACE, __LINE__);
 
@@ -365,6 +399,13 @@ void loop() {
   delay(startPumpMillis == 0 && currentMillis - refreshPagesMillis > 5000 ? 300 : 2);  // React quickly on startup and page load as well as when pump is running
 }
 
+/**
+ * @brief Sends a GET request to emptyWaterURL to signal an empty water tank.
+ *
+ * No-op when emptyWaterURL is unset or still at its default placeholder value.
+ * Side effects: HTTP GET to configured URL.  Blocking up to 5 s (http.setTimeout).
+ * Thread-safety: main task only.
+ */
 void doEmptyWaterWarning() {
   debugln(DEBUG_TRACE, __LINE__);
   if (emptyWaterURL == "" || emptyWaterURL == DEFAULT_URL_EMPTY) {
@@ -375,8 +416,10 @@ void doEmptyWaterWarning() {
     debugln(DEBUG_VERBOSE, "Request: " + emptyWaterURL);
     HTTPClient http;
     http.begin(String(emptyWaterURL));
+    http.setTimeout(5000);  // IMP-01: explicit 5 s timeout; avoids blocking pump control loop.
     int httpResponseCode = http.GET();
-    debugln(DEBUG_VERBOSE, "Response: " + httpResponseCode);
+    // BUG-04 fix: use String() to force string concatenation instead of pointer arithmetic.
+    debugln(DEBUG_VERBOSE, String("Response: ") + httpResponseCode);
     if (httpResponseCode != 200)
       debugln(DEBUG_ERROR, "doEmptyWaterWarning response code: " + http.getString());
     http.end();
@@ -385,6 +428,14 @@ void doEmptyWaterWarning() {
   }
 }
 
+/**
+ * @brief Sends current humidity and threshold values to reportURL.
+ *
+ * Query parameters appended: oah=<avg>, t1=<upper>, t2=<lower>.
+ * No-op when reportURL is unset or still at its default placeholder value.
+ * Side effects: HTTP GET to configured URL.  Blocking up to 5 s (http.setTimeout).
+ * Thread-safety: main task only.
+ */
 void doStatusReporting() {
   debugln(DEBUG_TRACE, __LINE__);
   if (reportURL == "" || reportURL == DEFAULT_URL_STATUS) {
@@ -396,8 +447,10 @@ void doStatusReporting() {
     debugln(DEBUG_VERBOSE, "Request: " + tmpReportUrl);
     HTTPClient http;
     http.begin(tmpReportUrl);
+    http.setTimeout(5000);  // IMP-01: explicit 5 s timeout; avoids blocking pump control loop.
     int httpResponseCode = http.GET();
-    debugln(DEBUG_VERBOSE, "Response: " + httpResponseCode);
+    // BUG-04 fix: use String() to force string concatenation instead of pointer arithmetic.
+    debugln(DEBUG_VERBOSE, String("Response: ") + httpResponseCode);
     if (httpResponseCode != 200) {
       debugln(DEBUG_ERROR, "doStatusReporting response code: " + http.getString());
     }
@@ -407,6 +460,13 @@ void doStatusReporting() {
   }
 }
 
+/**
+ * @brief Returns a JSON-style array string of raw average sensor values.
+ *
+ * Format: "[val0,val1,...]".  Values are the exponentially-smoothed ADC readings
+ * (not %-normalised).  Buffer size is 7 bytes per value.
+ * @return Arduino String containing the array.
+ */
 String getAvgValues() {
   debugln(DEBUG_TRACE, __LINE__);
   char buffer[7];
@@ -420,6 +480,13 @@ String getAvgValues() {
   return retVal + "]";
 }
 
+/**
+ * @brief Activates the pump relay (LOW-active) and records start timestamps.
+ *
+ * Sets startPumpMillis and lastPumpStartMillis to millis().
+ * Side effects: GPIO PUMP_ACTIVE_GPIO_NUMBER driven LOW.
+ * Thread-safety: main task only.
+ */
 void startPump() {
   debugln(DEBUG_INFO, "Starting Pump, run " + String(pumpCycleIndex) + " in cycle");
   digitalWrite(PUMP_ACTIVE_GPIO_NUMBER, LOW);
@@ -427,16 +494,30 @@ void startPump() {
   lastPumpStartMillis = startPumpMillis;
 }
 
+/**
+ * @brief Deactivates the pump relay and clears startPumpMillis.
+ *
+ * Side effects: GPIO PUMP_ACTIVE_GPIO_NUMBER driven HIGH.
+ * Thread-safety: main task only.
+ */
 void stopPump() {
   debugln(DEBUG_INFO, "Stopping Pump, run " + String(pumpCycleIndex) + " in cycle");
   digitalWrite(PUMP_ACTIVE_GPIO_NUMBER, HIGH);
   startPumpMillis = 0;
 }
 
+/**
+ * @brief Attempts WiFi connection using stored credentials then ssidAndPassword.h fallback.
+ *
+ * Each attempt waits up to 20 s.  On success: starts HTTP server, configures NTP, blinks LED.
+ * Called from setup() and from doCheckWiFiConnection() in loop().
+ * @return true if connected, false otherwise.
+ */
 // Will only be called from setup() once and in loop IF no connection
 bool connectToWiFi() {
-  // Try the stored values for ssid and password, if any
-  if (ssid != NULL && pwd != NULL) {
+  // BUG-03 fix: prefs.getString() returns "" for missing keys, never NULL.
+  // Use .isEmpty() instead of == NULL to avoid undefined behaviour in String::compareTo.
+  if (!ssid.isEmpty() && !pwd.isEmpty()) {
     debugln(DEBUG_INFO, "Connecting to SSID: " + ssid);
     WiFi.begin(ssid, pwd);
     for (int t = 0; t < 20; t++) {  // Try for 20 seconds
@@ -479,6 +560,12 @@ bool connectToWiFi() {
   }
 }
 
+/**
+ * @brief Checks WiFi status and reconnects if the connection was lost.
+ *
+ * Called once per 60 s from the main loop.  Delegates to connectToWiFi().
+ * Thread-safety: main task only.
+ */
 void doCheckWiFiConnection() {
   debugln(DEBUG_TRACE, __LINE__);
   if (WiFi.status() != WL_CONNECTED) {
@@ -526,6 +613,15 @@ String wpspin2string(uint8_t a[]) {
   return (String)wps_pin;
 }
 
+/**
+ * @brief WiFi and WPS event handler — called from a separate FreeRTOS task.
+ *
+ * @warning Accesses shared globals (ssid, pwd, checkWifiConnectionFlag, debugBuffer*).
+ *          These accesses are not mutex-protected (BUG-06); checkWifiConnectionFlag is
+ *          declared volatile as a minimum guard.
+ * @param event  WiFi event type.
+ * @param info   Event-specific payload.
+ */
 // WARNING: WiFiEvent is called from a separate FreeRTOS task (thread)!
 void WiFiEvent(WiFiEvent_t event, arduino_event_info_t info) {
   debugln(DEBUG_TRACE, __LINE__);
@@ -535,7 +631,7 @@ void WiFiEvent(WiFiEvent_t event, arduino_event_info_t info) {
       break;
     case ARDUINO_EVENT_WIFI_STA_GOT_IP:
       debugln(DEBUG_INFO, "Connecting to SSID: " + WiFi.SSID());
-      debugln(DEBUG_TRACE, "Password: " + WiFi.psk());
+      // BUG-07 fix: PSK must not be stored in the HTTP-accessible debug buffer.
       ssid = WiFi.SSID();
       pwd = WiFi.psk();
       prefs.putString("ssid", ssid);
@@ -573,6 +669,15 @@ void WiFiEvent(WiFiEvent_t event, arduino_event_info_t info) {
   }
 }
 
+/**
+ * @brief Handles one incoming HTTP request and sends the appropriate response.
+ *
+ * Parses the raw HTTP request from the WiFiClient line by line.  Serves the
+ * configuration page (GET /), AJAX endpoints (/H /O /M /P), static assets
+ * (jQuery, CSS), debug pages (/Da /Db /Dc), and processes the settings form (POST /).
+ * Blocking: reads until client disconnects.  Called from loop().
+ * Thread-safety: main task only.
+ */
 void webServerReaction() {
   debugln(DEBUG_TRACE, __LINE__);
   WiFiClient client = server.accept();
@@ -626,10 +731,7 @@ void webServerReaction() {
           } else if (currentLine.startsWith("GET /O")) {
             debugln(DEBUG_DEBUG, client.remoteIP().toString() + " -> Average humidity block: " + currentLine);
             page = PAGE_HUMIDITY;
-          } else if (currentLine.startsWith("GET /M")) {
-            debugln(DEBUG_DEBUG, client.remoteIP().toString() + " -> Current hysteresis mode: " + currentLine);
-            page = PAGE_MODE;
-          } else if (currentLine.startsWith("GET /P")) {
+          } else if (currentLine.startsWith("GET /P")) {  // BUG-08 fix: removed duplicate GET /M branch that was dead code.
             debugln(DEBUG_DEBUG, client.remoteIP().toString() + " -> Pump current block: " + currentLine);
             page = PAGE_PUMPVAL;
           } else if (currentLine.startsWith("GET /T")) {
@@ -1118,6 +1220,12 @@ void webServerReaction() {
   }
 }
 
+/**
+ * @brief Starts WPS push-button mode and registers the WiFi event handler.
+ *
+ * Registers WiFiEvent(), sets station mode, initialises WPS config and starts WPS.
+ * The WiFiEvent callback stores credentials and calls server.begin() on success.
+ */
 void wpsSetup() {
   WiFi.onEvent(WiFiEvent);  // Will call WiFiEvent() from another thread.
   WiFi.mode(WIFI_MODE_STA);

--- a/README.md
+++ b/README.md
@@ -1,20 +1,244 @@
-## Plantcare is an automatic plant watering system with water tank level monitoring via ESP32
-* It will call a website of your choice when the water tank is empty so you can do whatever you want with the information like send yourself an e-mail or use MQTT or whatnot.
-* It will call another website of your choice with the current humidity value as it changes so you can keep track of the humidity of your plant.
-* Supports up to three humidity sensors and uses their average value for big pots.
-* Automatically switches to Push button WPS ( https://en.wikipedia.org/wiki/Wi-Fi_Protected_Setup ) within 40 seconds of not being able to connect to any Wifi network on cold start, e.g. on first use.
-* Can be configured via Web browser:
+# Plantcare
+
+<!-- DE -->
+## Beschreibung (DE)
+
+Plantcare ist ein automatisches Pflanzenbewässerungssystem auf Basis des ESP32.
+Es misst die Bodenfeuchte über bis zu drei kapazitive Sensoren, steuert eine Pumpe
+per Relais und kann optional Statusinformationen an selbst gehostete HTTP-Endpunkte
+senden.  Die gesamte Konfiguration erfolgt bequem über den integrierten Webserver im
+Browser.
+
+<!-- EN -->
+## Description (EN)
+
+Plantcare is an automatic plant watering system built around the ESP32.
+It reads up to three capacitive soil-moisture sensors, drives a pump via a relay using
+a two-threshold hysteresis loop, and optionally reports telemetry to user-supplied HTTP
+endpoints.  A built-in web server provides full browser-based configuration and a live
+debug log page.
+
+---
 
 <center><img src="https://raw.githubusercontent.com/Joghurt/Plantcare/refs/heads/main/screenshot.png"></center>
 
-## Necessary Hardware
-To build this you need an ESP32 (e.g. https://www.amazon.de/dp/B0D9LFM1MG ) as well as a humidity sensor, relais and pump (e.g. https://www.amazon.de/dp/B0814HXWVV ), a 3.9 Ohm resistor, a 47uF capacitor and maybe additional sensors (e.g. https://www.amazon.de/dp/B08GCRZVSR ). Also get a large USB power adapter that ideally uses USB-C and a good cable.
-See the Fritzing image for how to wire everything.
+---
 
-## Necessary Software
-Download https://code.jquery.com/jquery-3.7.1.min.js into the project directory.
-Also see the top of the *.ino file for board package and libraries to install into the Arduino IDE.
+## Features / Funktionen
 
-## Possible Problems
-* Make sure to open the project by double clicking the *.ino file in its directory or you may encounter an "Error: file not found: jquery-3.7.1.min.js" when compiling.
-* If the power supply can not deliver enough power the ESP will brownout and restart and the pump will run several seconds longer.
+* Supports 1–3 capacitive humidity sensors; uses their average value.
+* Hysteresis pump control: upper threshold stops cyclic pumping, lower threshold restarts it.
+* Push-button WPS fallback — activated automatically 40 s after a failed WiFi connection on cold start.
+* HTTP callback when the water tank is empty (configurable URL).
+* HTTP telemetry of current humidity values (configurable URL).
+* In-browser configuration and debug log viewer.
+
+---
+
+## Build / Toolchain
+
+| Item | Value |
+|---|---|
+| Language | C++ (Arduino dialect, ESP32 Arduino core) |
+| Board package | **esp32** by Espressif Systems — install via Arduino IDE Board Manager |
+| Required libraries | **URLCode** by XieXuan; **incbin** by AlexIII (install via Arduino IDE Library Manager) |
+| Runtime dependency | `jquery-3.7.1.min.js` — download separately (see below) |
+| Tested hardware | WEMOS D1 MINI ESP32 |
+
+---
+
+## Hardware
+
+Required:
+* ESP32 board (e.g. WEMOS D1 MINI ESP32)
+* Capacitive soil-moisture sensor + relay module + small water pump
+* 3.9 Ω resistor, 47 µF capacitor
+* USB-C power supply with sufficient current headroom (brownout = pump runs longer!)
+
+See the Fritzing diagram for wiring details.  Fritzing part sources are listed in the
+file header of `Plantcare.ino`.
+
+---
+
+## Run / Flash / Deploy
+
+### ESP32 firmware
+
+1. Clone or download the repository.
+2. Download `jquery-3.7.1.min.js` from https://code.jquery.com/jquery-3.7.1.min.js
+   and place it in the **same directory** as `Plantcare.ino`.
+   (Failing to do this causes an "Error: file not found: jquery-3.7.1.min.js" at compile time.)
+3. Open `Plantcare.ino` by **double-clicking** it (opens the full Arduino project folder).
+4. Install the board package and libraries listed above.
+5. Select the correct board and COM port; click **Upload**.
+
+### PHP backend (optional)
+
+Deploy `index.php`, `status.php`, `empty.php`, and a `db.php` (not included — provide
+your own with a `$dbcon` MySQLi connection, a `db_query()` wrapper, and a `sendMail()`
+helper) to a PHP-capable web server with a MySQL/MariaDB database.
+
+Expected DB schema (minimum):
+
+```sql
+CREATE TABLE Humidity (Id INT AUTO_INCREMENT PRIMARY KEY, Date DATETIME DEFAULT NOW(), Average FLOAT);
+CREATE TABLE Config   (Id VARCHAR(20) PRIMARY KEY, Value VARCHAR(100));
+INSERT INTO Config VALUES ('Threshold1', '70'), ('Threshold2', '50');
+```
+
+---
+
+## Configuration
+
+### WiFi credentials
+
+Edit `ssidAndPassword.h` with your SSID and password **or** use WPS push-button mode
+(the ESP switches to WPS automatically 40 s after a failed connection attempt).
+Credentials entered via WPS or the web UI are persisted in ESP32 NVS.
+
+> **Security note:** Do not commit real credentials to a public repository.
+> The file `ssidAndPassword.h` is intentionally kept as a plaintext fallback for
+> environments without WPS.  Consider adding it to `.gitignore`.
+
+### Runtime settings (web UI)
+
+Navigate to the ESP32's IP address in a browser.  All settings are stored in NVS and
+survive power cycles.
+
+| Parameter | Description | Default |
+|---|---|---|
+| Sensor GPIOs | Enable/disable sensors; calibrate dry/wet ADC values | GPIO 34 active; dry=670, wet=260 |
+| Upper hysteresis (%) | Pumping deactivated above this humidity | 70 % |
+| Lower hysteresis (%) | Pumping activated below this humidity | 50 % |
+| First pump runtime (s) | Duration of first pump activation per cycle | 7 s |
+| First pump delay (min) | Delay before second activation per cycle | 360 min |
+| Other pump runtimes (s) | Duration of subsequent activations | 0.8 s |
+| Other pump delays (min) | Minimum delay between subsequent activations | 180 min |
+| Water detection (mA) | Pump current threshold for empty-tank detection | 250 mA |
+| Empty-warning URL | Called via HTTP GET when tank is empty | — |
+| Status-report URL | Called via HTTP GET with current humidity | — |
+| Debug level | Error / Warn / Info / Verbose / Debug / Trace | Info |
+| Serial debug | Mirror debug log to UART @ 115200 baud | off |
+
+---
+
+## Architecture / Modules
+
+```
+Plantcare.ino
+├── setup()              — One-time init: ADC, GPIO, NVS, WiFi, NTP
+├── loop()               — Main control loop (~20 ms cycle when pump idle)
+│   ├── webServerReaction()   — Blocking HTTP request handler (one client/iteration)
+│   ├── Sensor averaging      — Exponential moving average (α=0.02)
+│   ├── Hysteresis logic      — Two-threshold pump mode control
+│   ├── doStatusReporting()   — HTTP GET telemetry (on ≥0.5 % change)
+│   ├── doCheckWiFiConnection()— WiFi reconnect (every 60 s)
+│   └── Pump control          — startPump / stopPump / current measurement
+├── WiFiEvent()          — FreeRTOS task: WPS + WiFi event handler [!shared state]
+└── wpsSetup()           — Initiates WPS push-button mode
+```
+
+**Concurrency:**  
+`WiFiEvent()` runs in a separate FreeRTOS task.  It writes to `ssid`, `pwd`,
+`checkWifiConnectionFlag`, and the debug ring buffer without a mutex.
+`checkWifiConnectionFlag` is declared `volatile`; full mutex protection of the String
+globals is a known limitation (see CHANGELOG).
+
+**Pump GPIO:**  GPIO 33 — LOW-active relay (HIGH = off, LOW = on).  
+**Sensor GPIOs:** 34, 35, 39 (ADC1, 10-bit resolution, 0–1023).  
+**Current sense:** GPIO 36 — ADC reading scaled by `PUMP_CURRENT_MULTIPLIER` (2.8).
+
+---
+
+## Interfaces
+
+| Interface | Direction | Description |
+|---|---|---|
+| WiFi HTTP server :80 | inbound | Config UI, AJAX endpoints, static assets |
+| `emptyWaterURL` (HTTP GET) | outbound | Empty-tank notification |
+| `reportURL?oah=&t1=&t2=` (HTTP GET) | outbound | Humidity telemetry |
+| NVS (ESP32 Preferences) | local | Persistent settings, namespace `"p"` |
+| UART 115200 (optional) | outbound | Serial debug mirror |
+
+### HTTP Endpoints (ESP32 built-in server)
+
+| Path | Method | Returns |
+|---|---|---|
+| `/` | GET | HTML config page |
+| `/` | POST | Saves config, redirects |
+| `/H?<n>` | GET | JSON: raw ADC value for sensor n |
+| `/H` | GET | JSON: array of all raw ADC values |
+| `/O` | GET | JSON: overall average humidity (%) |
+| `/M` | GET | Text: "Rising" or "Falling" |
+| `/P` | GET | JSON: last pump current (mA) |
+| `/jq.js` | GET | jQuery 3.7.1 (cached 10 h) |
+| `/s.css /d.css /n.css` | GET | Stylesheets (cached 10 h) |
+| `/Da /Db /Dc` | GET | Debug log pages |
+| `/T` | GET | Trigger pump test |
+| `/E` | GET | Trigger empty-water warning |
+| `/R` | GET | Trigger status report |
+
+---
+
+## Tests / Static Analysis
+
+No automated test suite exists for this project (embedded hardware required for
+meaningful integration tests).
+
+For static analysis on the C++ code, `cppcheck` can be run against the `.ino` file
+treated as C++14:
+
+```sh
+cppcheck --std=c++14 --enable=all --language=c++ Plantcare.ino
+```
+
+The PHP files can be checked with:
+
+```sh
+php -l status.php
+php -l index.php
+php -l empty.php
+```
+
+---
+
+## File Structure
+
+```
+Plantcare/
+├── Plantcare.ino          # ESP32 firmware (main sketch)
+├── ssidAndPassword.h      # WiFi fallback credentials (do not commit real passwords)
+├── jquery-3.7.1.min.js    # jQuery (download separately, not in repo)
+├── s.css                  # Base stylesheet (served by ESP32)
+├── d.css                  # Day theme stylesheet
+├── n.css                  # Night theme stylesheet
+├── index.php              # Optional: humidity chart (Chart.js, PHP backend)
+├── status.php             # Optional: telemetry receiver endpoint
+├── empty.php              # Optional: empty-tank notification endpoint
+├── CHANGELOG.md           # Change history
+├── README.md              # This file
+└── LICENSE
+```
+
+---
+
+## Limitations / Known Issues
+
+* **BUG-06 (data race):** `WiFiEvent` runs in a FreeRTOS task and writes to shared
+  `String` globals without a mutex.  Occasional garbled debug output or spurious
+  reconnects are theoretically possible.  Full fix would require FreeRTOS semaphores.
+* **No HTTPS on ESP32 web server:** The built-in HTTP server serves plain HTTP.
+  Use only on a trusted local network.
+* **No authentication** on the web UI: anyone on the same network can change settings
+  or trigger the pump.
+* **Single-client HTTP server:** `webServerReaction()` handles one request per
+  `loop()` iteration; concurrent browser tabs may stall briefly.
+* Browsing to `d.css` or `n.css` directly switches the active stylesheet as a side
+  effect (intentional Easter egg).
+
+---
+
+## Changelog / Lizenz
+
+See [CHANGELOG.md](CHANGELOG.md) for a detailed history of changes.  
+Licensed under the terms in [LICENSE](LICENSE).

--- a/index.php
+++ b/index.php
@@ -58,15 +58,16 @@
 				datasets: [{
 						label: 'Upper Threshold',
 						data: [
-							{t:'<?=$row2['Start']?>', y:<?=$row['Upper']?>},
-							{t:'<?=$row2['End']?>', y:<?=$row['Upper']?>}
+							/* BUG-02 fix: cast numeric values, escape date strings to prevent stored XSS */
+							{t:'<?=htmlspecialchars((string)$row2['Start'],ENT_QUOTES,'UTF-8')?>', y:<?=(float)$row['Upper']?>},
+							{t:'<?=htmlspecialchars((string)$row2['End'],ENT_QUOTES,'UTF-8')?>', y:<?=(float)$row['Upper']?>}
 						],
 						borderColor: 'rgba(255, 0, 0, .5)',
 					}, {
 						label: 'Lower Threshold',
 						data: [
-							{t:'<?=$row2['Start']?>', y:<?=$row['Lower']?>},
-							{t:'<?=$row2['End']?>', y:<?=$row['Lower']?>}
+							{t:'<?=htmlspecialchars((string)$row2['Start'],ENT_QUOTES,'UTF-8')?>', y:<?=(float)$row['Lower']?>},
+							{t:'<?=htmlspecialchars((string)$row2['End'],ENT_QUOTES,'UTF-8')?>', y:<?=(float)$row['Lower']?>}
 						],
 						borderColor: 'rgba(0, 0, 255, .5)',
 					}, {
@@ -75,7 +76,7 @@
 					label: 'Humidity Values',
 					data: [
 <?	foreach (db_query("SELECT Date, Average FROM Humidity WHERE Date > SUBDATE(NOW(), 8) ORDER BY Id")->fetch_all() AS $x) { ?>
-						{t:'<?=$x[0]?>', y:<?=$x[1]?>},
+						{t:'<?=htmlspecialchars((string)$x[0],ENT_QUOTES,'UTF-8')?>', y:<?=(float)$x[1]?>},
 <?	} ?>
 					],
 					borderColor: 'rgba(0, 255, 0, 1)',

--- a/status.php
+++ b/status.php
@@ -1,8 +1,31 @@
 <?php
+	/**
+	 * @brief Receives humidity telemetry from the ESP32 and writes it to the database.
+	 *
+	 * GET parameters: oah=<float> (overall average humidity), t1=<int> (upper threshold), t2=<int> (lower threshold)
+	 * Security: all inputs are bound via prepared statements — no SQL injection possible.
+	 */
 	require_once "db.php";
-	db_query("INSERT INTO Humidity (Average) VALUES ('".$_REQUEST['oah']."')") or die($dbcon->error." (".$dbcon->errno.")");
-	if ($_REQUEST['t1'])
-		db_query("UPDATE Config SET Value='".$_REQUEST['t1']."' WHERE Id='Threshold1'") or die($dbcon->error." (".$dbcon->errno.")");
-	if ($_REQUEST['t2'])
-		db_query("UPDATE Config SET Value='".$_REQUEST['t2']."' WHERE Id='Threshold2'") or die($dbcon->error." (".$dbcon->errno.")");
+
+	// BUG-01 fix: use prepared statements to prevent SQL injection.
+	$oah = (float)($_REQUEST['oah'] ?? 0);
+	$stmt = $dbcon->prepare("INSERT INTO Humidity (Average) VALUES (?)");
+	$stmt->bind_param("d", $oah);
+	$stmt->execute() or die($dbcon->error . " (" . $dbcon->errno . ")");
+	$stmt->close();
+
+	if (!empty($_REQUEST['t1'])) {
+		$t1 = (int)$_REQUEST['t1'];
+		$stmt = $dbcon->prepare("UPDATE Config SET Value=? WHERE Id='Threshold1'");
+		$stmt->bind_param("i", $t1);
+		$stmt->execute() or die($dbcon->error . " (" . $dbcon->errno . ")");
+		$stmt->close();
+	}
+	if (!empty($_REQUEST['t2'])) {
+		$t2 = (int)$_REQUEST['t2'];
+		$stmt = $dbcon->prepare("UPDATE Config SET Value=? WHERE Id='Threshold2'");
+		$stmt->bind_param("i", $t2);
+		$stmt->execute() or die($dbcon->error . " (" . $dbcon->errno . ")");
+		$stmt->close();
+	}
 ?>


### PR DESCRIPTION
Dieser Commit behebt mehrere Sicherheitslücken und Stabilitätsprobleme, die beim Code-Quality-Pass gefunden wurden.

Security:
- status.php: SQL-Injection geschlossen – alle drei Queries auf MySQLi Prepared Statements umgestellt (war direktes Einschleusen beliebiger SQL-Befehle via GET-Parameter möglich)
- index.php: Stored-XSS-Lücke geschlossen – DB-Ausgaben in JS-Kontext werden jetzt mit htmlspecialchars() escapiert bzw. per (float)/(int) gecastet
- Plantcare.ino: WiFi-Passwort wurde in den über HTTP öffentlich abrufbaren Debug-Ringpuffer geschrieben – Zeile entfernt

Crashes / Undefined Behavior:
- Plantcare.ino: Division durch Null beim Erststart (kein Sensor konfiguriert) führte zu CPU-Exception und Boot-Schleife – Guards hinzugefügt
- Plantcare.ino: "Response: " + httpResponseCode führte C-Zeiger- Arithmetik aus statt String-Konkatenation – zu String(...) + int korrigiert
- Plantcare.ino: String == NULL-Vergleiche durch .isEmpty() ersetzt (NULL-Dereferenz in strcmp möglich)

Robustness:
- HTTP-Timeout (5 s) in doEmptyWaterWarning() und doStatusReporting() gesetzt, damit ein hängender Server die Pump-Abschaltelogik nicht blockiert
- Rückgabewert von prefs.begin() wird geprüft und bei NVS-Fehler geloggt
- checkWifiConnectionFlag als volatile deklariert (FreeRTOS-Task-Zugriff)
- Toter Code: doppelten GET /M Handler entfernt

Docs:
- Doxygen-Dateiheader und Funktionskommentare für alle public APIs
- CHANGELOG.md angelegt
- README.md vollständig überarbeitet (zweisprachig DE/EN, Architektur, Schnittstellen, Build-Anleitung, bekannte Limitierungen)